### PR TITLE
Resolve path when traversing parents

### DIFF
--- a/project_paths/__init__.py
+++ b/project_paths/__init__.py
@@ -278,7 +278,7 @@ def _find_pyproject_by_parent_traversal(base: Path) -> Path:
     Returns the path to pyproject.toml relative to the given base path.
     Traverses BACKWARDS starting from the base and going out of the parents.
     """
-    for directory in [base, *base.parents]:
+    for directory in [base, *base.resolve().parents]:
         candidate = directory / "pyproject.toml"
         if candidate.is_file():
             return candidate


### PR DESCRIPTION
This fixes locating pyproject.toml in a parent directory.

Currently in a project like

```
myproject
    pyproject.toml
    scripts
        myscript.py
```

Calling myscript.py within the scripts directory will give
```
project_paths.PyProjectNotFoundError: cannot find pyproject.toml within . or any of its parents
```

Since the `base` in `_find_pyproject_by_parent_traversal` is `.` and `list(base.parents) == []`

But with `resolve()` all the parents are found:

```
list(base.resolve().parents)
Out[7]:
[PosixPath('/Users/username/Code/myproject'),
 PosixPath('/Users/username/Code'),
 PosixPath('/Users/username'),
 PosixPath('/Users'),
 PosixPath('/')]
```